### PR TITLE
Node.js 12 actions are deprecated.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: 'value for the connection string'
     default: ''
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'settings'


### PR DESCRIPTION
Since Node.js 12 is no longer supported as of April 2022 and is deprecated, I updated Node to version 16.

Fixes #328